### PR TITLE
Fixed Gulp tasks - Linking

### DIFF
--- a/templates/tasks/config/sails-linker-gulp.js
+++ b/templates/tasks/config/sails-linker-gulp.js
@@ -4,156 +4,285 @@
  * ---------------------------------------------------------------
  *
  * Automatically inject <script> tags for javascript files and <link> tags
- * for css files.  Also automatically links an output file containing precompiled
+ * for css files. Also automatically links an output file containing precompiled
  * templates using a <script> tag.
  *
- * For usage docs see:
+ * For usage docs see (the original):
  * 		https://github.com/Zolmeister/grunt-sails-linker
  *
  */
-// todo - add css and templates sections to layout.ejs. add prod,dev, etc
 module.exports = function(gulp, plugins, growl) {
-	gulp.task('sails-linker-gulp:devJs', function() {
+
+	// Insert JS, CSS and template dev links into HTML files in the tmp assets folder
+	gulp.task('sails-linker-gulp:devAssets', function() {
 		// Read templates
-		return gulp.src(['.tmp/public/**/*.html', 'views/**/*.html', 'views/**/*.ejs'])
-				// Link the JavaScript
-				.pipe(plugins.linker({
-					scripts: [require('../pipeline').jsFilesToInject],
-					startTag: '<!--SCRIPTS-->',
-					endTag: '<!--SCRIPTS END-->',
-					fileTmpl: '<script src="%s"></script>',
-					appRoot: '.tmp/public'
-				}))
-				// Write modified files to www/
-				.pipe(gulp.dest('views/'))
-				.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp devJs task complete' })));
+		return gulp.src('.tmp/public/**/*.html')
+		// Link the javaScript
+		.pipe(plugins.linker({
+			scripts: [require('../pipeline').jsFilesToInject],
+			startTag: '<!--SCRIPTS-->',
+			endTag: '<!--SCRIPTS END-->',
+			fileTmpl: '<script src="%s"></script>',
+			appRoot: '.tmp/public'
+		}))
+		// Link the styles
+		.pipe(plugins.linker({
+			scripts: [require('../pipeline').cssFilesToInject],
+			startTag: '<!--STYLES-->',
+			endTag: '<!--STYLES END-->',
+			fileTmpl: '<link rel="stylesheet" href="%s">',
+			appRoot: '.tmp/public'
+		}))
+		// Link the JST Templates
+		.pipe(plugins.linker({
+			scripts: ['.tmp/public/jst.js'],
+			startTag: '<!--TEMPLATES-->',
+			endTag: '<!--TEMPLATES END-->',
+			fileTmpl: '<script type="text/javascript" src="%s"></script>',
+			appRoot: '.tmp/public',
+		}))
+		// Write modified files...
+		.pipe(gulp.dest('.tmp/public/'))
+		.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp:devAssets task complete' })));
 	});
 	  
-	gulp.task('sails-linker-gulp:devJsRelative', function() {
+	// Insert JS, CSS and template dev links into HTML and EJS files in the views folder
+	gulp.task('sails-linker-gulp:devViews', function() {
 		// Read templates
-		return gulp.src(['.tmp/public/**/*.html', 'views/**/*.html', 'views/**/*.ejs'])
-				// Link the JavaScript
-				.pipe(plugins.linker({
-					scripts: [require('../pipeline').jsFilesToInject],
-					startTag: '<!--SCRIPTS-->',
-					endTag: '<!--SCRIPTS END-->',
-					fileTmpl: '<script src="%s"></script>',
-					appRoot: '.tmp/public',
-					relative: true
-				}))
-				// Write modified files to www/
-				.pipe(gulp.dest('views/'))
-				.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp devJsRelative task complete' })));
+		return gulp.src(['views/**/*.html', 'views/**/*.ejs'])
+		// Link the javaScript
+		.pipe(plugins.linker({
+			scripts: [require('../pipeline').jsFilesToInject],
+			startTag: '<!--SCRIPTS-->',
+			endTag: '<!--SCRIPTS END-->',
+			fileTmpl: '<script src="%s"></script>',
+			appRoot: '.tmp/public'
+		}))
+		// Link the styles
+		.pipe(plugins.linker({
+			scripts: [require('../pipeline').cssFilesToInject],
+			startTag: '<!--STYLES-->',
+			endTag: '<!--STYLES END-->',
+			fileTmpl: '<link rel="stylesheet" href="%s">',
+			appRoot: '.tmp/public'
+		}))
+		// Link the JST Templates
+		.pipe(plugins.linker({
+			scripts: ['.tmp/public/jst.js'],
+			startTag: '<!--TEMPLATES-->',
+			endTag: '<!--TEMPLATES END-->',
+			fileTmpl: '<script type="text/javascript" src="%s"></script>',
+			appRoot: '.tmp/public',
+		}))
+		// Write modified files...
+		.pipe(gulp.dest('views/'))
+		.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp:devViews task complete' })));
+	});
+	  
+	// Insert relative JS, CSS and template dev links into HTML files in the tmp assets folder
+	gulp.task('sails-linker-gulp:devAssetsRelative', function() {
+		// Read templates
+		return gulp.src('.tmp/public/**/*.html')
+		// Link the JavaScript
+		.pipe(plugins.linker({
+			scripts: [require('../pipeline').jsFilesToInject],
+			startTag: '<!--SCRIPTS-->',
+			endTag: '<!--SCRIPTS END-->',
+			fileTmpl: '<script src="%s"></script>',
+			appRoot: '.tmp/public',
+			relative: true
+		}))
+		// Link the styles
+		.pipe(plugins.linker({
+			scripts: [require('../pipeline').cssFilesToInject],
+			startTag: '<!--STYLES-->',
+			endTag: '<!--STYLES END-->',
+			fileTmpl: '<link rel="stylesheet" href="%s">',
+			appRoot: '.tmp/public',
+			relative: true
+		}))
+		// Link the JST Templates
+		.pipe(plugins.linker({
+			scripts: ['.tmp/public/jst.js'],
+			startTag: '<!--TEMPLATES-->',
+			endTag: '<!--TEMPLATES END-->',
+			fileTmpl: '<script type="text/javascript" src="%s"></script>',
+			appRoot: '.tmp/public'
+		}))
+		// Write modified files...
+		.pipe(gulp.dest('.tmp/public/'))
+		.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp:devAssetsRelative task complete' })));
 	});
 	
-	gulp.task('sails-linker-gulp:prodJs', function() {
+	// Insert relative JS, CSS and template dev links into HTML and EJS files in the views folder
+	gulp.task('sails-linker-gulp:devViewsRelative', function() {
 		// Read templates
-		return gulp.src(['.tmp/public/**/*.html', 'views/**/*.html', 'views/**/*.ejs'])
-				// Link the JavaScript
-				.pipe(plugins.linker({
-					scripts: ['.tmp/public/min/production.min.js'],
-					startTag: '<!--SCRIPTS-->',
-					endTag: '<!--SCRIPTS END-->',
-					fileTmpl: '<script src="%s"></script>',
-					appRoot: '.tmp/public'
-				}))
-				// Write modified files to www/
-				.pipe(gulp.dest('views/'))
-				.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp prodJs task complete' })));
+		return gulp.src(['views/**/*.html', 'views/**/*.ejs'])
+		// Link the javaScript
+		.pipe(plugins.linker({
+			scripts: [require('../pipeline').jsFilesToInject],
+			startTag: '<!--SCRIPTS-->',
+			endTag: '<!--SCRIPTS END-->',
+			fileTmpl: '<script src="%s"></script>',
+			appRoot: '.tmp/public',
+			relative: true
+		}))
+		// Link the styles
+		.pipe(plugins.linker({
+			scripts: [require('../pipeline').cssFilesToInject],
+			startTag: '<!--STYLES-->',
+			endTag: '<!--STYLES END-->',
+			fileTmpl: '<link rel="stylesheet" href="%s">',
+			appRoot: '.tmp/public',
+			relative: true
+		}))
+		// Link the JST Templates
+		.pipe(plugins.linker({
+			scripts: ['.tmp/public/jst.js'],
+			startTag: '<!--TEMPLATES-->',
+			endTag: '<!--TEMPLATES END-->',
+			fileTmpl: '<script type="text/javascript" src="%s"></script>',
+			appRoot: '.tmp/public',
+		}))
+		// Write modified files...
+		.pipe(gulp.dest('views/'))
+		.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp:devViewsRelative task complete' })));
+	});
+	  
+	// Insert JS, CSS and template production links into HTML files in the tmp assets folder
+	gulp.task('sails-linker-gulp:prodAssets', function() {
+		// Read templates
+		return gulp.src('.tmp/public/**/*.html')
+		// Link the JavaScript
+		.pipe(plugins.linker({
+			scripts: ['.tmp/public/min/production.min.js'],
+			startTag: '<!--SCRIPTS-->',
+			endTag: '<!--SCRIPTS END-->',
+			fileTmpl: '<script src="%s"></script>',
+			appRoot: '.tmp/public'
+		}))
+		// Link the styles
+		.pipe(plugins.linker({
+			scripts: ['.tmp/public/min/production.min.css'],
+			startTag: '<!--STYLES-->',
+			endTag: '<!--STYLES END-->',
+			fileTmpl: '<link rel="stylesheet" href="%s">',
+			appRoot: '.tmp/public'
+		}))
+		// Link the JST Templates
+		.pipe(plugins.linker({
+			scripts: ['.tmp/public/jst.js'],
+			startTag: '<!--TEMPLATES-->',
+			endTag: '<!--TEMPLATES END-->',
+			fileTmpl: '<script type="text/javascript" src="%s"></script>',
+			appRoot: '.tmp/public',
+		}))
+		// Write modified files...
+		.pipe(gulp.dest('.tmp/public/'))
+		.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp:prodAssets task complete' })));
 	});
 	
-	gulp.task('sails-linker-gulp:prodJsRelative', function() {
+	// Insert JS, CSS and template production links into HTML and EJS files in the views folder
+	gulp.task('sails-linker-gulp:prodViews', function() {
 		// Read templates
-		return gulp.src(['.tmp/public/**/*.html', 'views/**/*.html', 'views/**/*.ejs'])
-				// Link the JavaScript
-				.pipe(plugins.linker({
-					scripts: ['.tmp/public/min/production.min.js'],
-					startTag: '<!--SCRIPTS-->',
-					endTag: '<!--SCRIPTS END-->',
-					fileTmpl: '<script src="%s"></script>',
-					appRoot: '.tmp/public',
-					relative: true
-				}))
-				// Write modified files to www/
-				.pipe(gulp.dest('views/'))
-				.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp prodJsRelative task complete' })));
+		return gulp.src(['views/**/*.html', 'views/**/*.ejs'])
+		// Link the JavaScript
+		.pipe(plugins.linker({
+			scripts: ['.tmp/public/min/production.min.js'],
+			startTag: '<!--SCRIPTS-->',
+			endTag: '<!--SCRIPTS END-->',
+			fileTmpl: '<script src="%s"></script>',
+			appRoot: '.tmp/public'
+		}))
+		// Link the styles
+		.pipe(plugins.linker({
+			scripts: ['.tmp/public/min/production.min.css'],
+			startTag: '<!--STYLES-->',
+			endTag: '<!--STYLES END-->',
+			fileTmpl: '<link rel="stylesheet" href="%s">',
+			appRoot: '.tmp/public'
+		}))
+		// Link the JST Templates
+		.pipe(plugins.linker({
+			scripts: ['.tmp/public/jst.js'],
+			startTag: '<!--TEMPLATES-->',
+			endTag: '<!--TEMPLATES END-->',
+			fileTmpl: '<script type="text/javascript" src="%s"></script>',
+			appRoot: '.tmp/public',
+		}))
+		// Write modified files...
+		.pipe(gulp.dest('views/'))
+		.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp:prodViews task complete' })));
 	});
 	
-	gulp.task('sails-linker-gulp:devStyles', function() {
+	// Insert relative JS, CSS and template production links into HTML files in the tmp assets folder
+	gulp.task('sails-linker-gulp:prodAssetsRelative', function() {
 		// Read templates
-		return gulp.src(['.tmp/public/**/*.html', 'views/**/*.html', 'views/**/*.ejs'])
-				.pipe(plugins.linker({
-					scripts: [require('../pipeline').cssFilesToInject],
-					startTag: '<!--STYLES-->',
-					endTag: '<!--STYLES END-->',
-					fileTmpl: '<link rel="stylesheet" href="%s">',
-					appRoot: '.tmp/public'
-				}))
-				// Write modified files to www/
-				.pipe(gulp.dest('views/'))
-				.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp devStyles task complete' })));
-	});
-  
-  	gulp.task('sails-linker-gulp:devStylesRelative', function() {
-		// Read templates
-		return gulp.src(['.tmp/public/**/*.html', 'views/**/*.html', 'views/**/*.ejs'])
-				.pipe(plugins.linker({
-					scripts: [require('../pipeline').cssFilesToInject],
-					startTag: '<!--STYLES-->',
-					endTag: '<!--STYLES END-->',
-					fileTmpl: '<link rel="stylesheet" href="%s">',
-					appRoot: '.tmp/public',
-					relative: true
-				}))
-				// Write modified files to www/
-				.pipe(gulp.dest('views/'))
-				.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp devStylesRelative task complete' })));
-	});
-
-	gulp.task('sails-linker-gulp:prodStyles', function() {
-		// Read templates
-		return gulp.src(['.tmp/public/index.html', 'views/**/*.html', 'views/**/*.ejs'])
-				.pipe(plugins.linker({
-					scripts: ['.tmp/public/min/production.min.css'],
-					startTag: '<!--STYLES-->',
-					endTag: '<!--STYLES END-->',
-					fileTmpl: '<link rel="stylesheet" href="%s">',
-					appRoot: '.tmp/public'
-				}))
-				// Write modified files to www/
-				.pipe(gulp.dest('views/'))
-				.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp prodStyles task complete' })));
+		return gulp.src('.tmp/public/**/*.html')
+		// Link the JavaScript
+		.pipe(plugins.linker({
+			scripts: ['.tmp/public/min/production.min.js'],
+			startTag: '<!--SCRIPTS-->',
+			endTag: '<!--SCRIPTS END-->',
+			fileTmpl: '<script src="%s"></script>',
+			appRoot: '.tmp/public',
+			relative: true
+		}))
+		// Link the styles
+		.pipe(plugins.linker({
+			scripts: ['.tmp/public/min/production.min.css'],
+			startTag: '<!--STYLES-->',
+			endTag: '<!--STYLES END-->',
+			fileTmpl: '<link rel="stylesheet" href="%s">',
+			appRoot: '.tmp/public',
+			relative: true
+		}))
+		// Link the JST Templates
+		.pipe(plugins.linker({
+			scripts: ['.tmp/public/jst.js'],
+			startTag: '<!--TEMPLATES-->',
+			endTag: '<!--TEMPLATES END-->',
+			fileTmpl: '<script type="text/javascript" src="%s"></script>',
+			appRoot: '.tmp/public',
+		}))
+		// Write modified files...
+		.pipe(gulp.dest('.tmp/public/'))
+		.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp:prodAssetsRelative task complete' })));
 	});
 	
-  	gulp.task('sails-linker-gulp:prodStylesRelative', function() {
+	// Insert relative JS, CSS and template production links into HTML and EJS files in the views folder
+	gulp.task('sails-linker-gulp:prodViewsRelative', function() {
 		// Read templates
-		return gulp.src(['.tmp/public/index.html', 'views/**/*.html', 'views/**/*.ejs'])
-				.pipe(plugins.linker({
-					scripts: ['.tmp/public/min/production.min.css'],
-					startTag: '<!--STYLES-->',
-					endTag: '<!--STYLES END-->',
-					fileTmpl: '<link rel="stylesheet" href="%s">',
-					appRoot: '.tmp/public',
-					relative: true
-				}))
-				// Write modified files to www/
-				.pipe(gulp.dest('views/'))
-				.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp prodStylesRelative task complete' })));
+		return gulp.src(['views/**/*.html', 'views/**/*.ejs'])
+		// Link the JavaScript
+		.pipe(plugins.linker({
+			scripts: ['.tmp/public/min/production.min.js'],
+			startTag: '<!--SCRIPTS-->',
+			endTag: '<!--SCRIPTS END-->',
+			fileTmpl: '<script src="%s"></script>',
+			appRoot: '.tmp/public',
+			relative: true
+		}))
+		// Link the styles
+		.pipe(plugins.linker({
+			scripts: ['.tmp/public/min/production.min.css'],
+			startTag: '<!--STYLES-->',
+			endTag: '<!--STYLES END-->',
+			fileTmpl: '<link rel="stylesheet" href="%s">',
+			appRoot: '.tmp/public',
+			relative: true
+		}))
+		// Link the JST Templates
+		.pipe(plugins.linker({
+			scripts: ['.tmp/public/jst.js'],
+			startTag: '<!--TEMPLATES-->',
+			endTag: '<!--TEMPLATES END-->',
+			fileTmpl: '<script type="text/javascript" src="%s"></script>',
+			appRoot: '.tmp/public',
+		}))
+		// Write modified files...
+		.pipe(gulp.dest('views/'))
+		.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp:prodViewsRelative task complete' })));
 	});
 	
-	gulp.task('sails-linker-gulp:devTpl', function() {
-		// Read templates
-		return gulp.src(['.tmp/public/index.html', 'views/**/*.html', 'views/**/*.ejs'])
-				// Link the JST Templates
-				.pipe(plugins.linker({
-					scripts: ['.tmp/public/jst.js'],
-					startTag: '<!--TEMPLATES-->',
-					endTag: '<!--TEMPLATES END-->',
-					fileTmpl: '<script type="text/javascript" src="%s"></script>',
-					appRoot: '.tmp/public',
-				}))
-				// Write modified files to www/
-				.pipe(gulp.dest('views/'))
-				.pipe(plugins.if(growl, plugins.notify({ message: 'sails-linker-gulp devTpl task complete' })));
-	});
 };

--- a/templates/tasks/config/watch.js
+++ b/templates/tasks/config/watch.js
@@ -22,7 +22,7 @@ module.exports = function(gulp, plugins, growl) {
 	
 	gulp.task('watch:assets', function() {
 		// Watch assets
-		return gulp.watch(['assets/**/**/*', 'tasks/pipeline.js'], ['syncAssets'])
+		return gulp.watch(['assets/**/*', 'tasks/pipeline.js'], ['syncAssets'])
 				.on('change', function(file) {
 					server.changed(file.path);
 				});

--- a/templates/tasks/register/buildProd.js
+++ b/templates/tasks/register/buildProd.js
@@ -2,9 +2,10 @@ module.exports = function (gulp, plugins) {
 	gulp.task('buildProd', function(cb) {
 		plugins.sequence(
 			'compileAssets',
-			'concat',
-			'uglify',
-			'cssmin',
+			'concat:js',
+			'concat:css',
+			'uglify:dist',
+			'cssmin:dist',
 			'linkAssetsBuildProd',
 			'clean:build',
 			'copy:build',

--- a/templates/tasks/register/linkAssets.js
+++ b/templates/tasks/register/linkAssets.js
@@ -1,12 +1,8 @@
 module.exports = function (gulp, plugins) {
 	gulp.task('linkAssets', function(cb) {
 		plugins.sequence(
-			'sails-linker-gulp:devJs',
-			'sails-linker-gulp:devStyles',
-			'sails-linker-gulp:devTpl',
-			/*'sails-linker-gulp:devJsJade',
-			'sails-linker-gulp:devStylesJade',
-			'sails-linker-gulp:devTplJade' */
+			'sails-linker-gulp:devAssets',
+			'sails-linker-gulp:devViews',
 			cb
 		);
 	});

--- a/templates/tasks/register/linkAssetsBuild.js
+++ b/templates/tasks/register/linkAssetsBuild.js
@@ -1,12 +1,8 @@
 module.exports = function (gulp, plugins) {
 	gulp.task('linkAssetsBuild', function(cb) {
 		plugins.sequence(
-			'sails-linker-gulp:devJsRelative',
-			'sails-linker-gulp:devStylesRelative',
-			'sails-linker-gulp:devTpl',
-			/*'sails-linker-gulp:devJsRelativeJade',
-			'sails-linker-gulp:devStylesRelativeJade',
-			'sails-linker-gulp:devTplJade' */
+			'sails-linker-gulp:devAssetsRelative',
+			'sails-linker-gulp:devViewsRelative',
 			cb
 		);
 	});

--- a/templates/tasks/register/linkAssetsBuildProd.js
+++ b/templates/tasks/register/linkAssetsBuildProd.js
@@ -1,12 +1,8 @@
 module.exports = function (gulp, plugins) {
 	gulp.task('linkAssetsBuildProd', function(cb) {
 		plugins.sequence(
-			'sails-linker-gulp:prodJsRelative',
-			'sails-linker-gulp:prodStylesRelative',
-			'sails-linker-gulp:devTpl',
-			/*'sails-linker-gulp:prodJsRelativeJade',
-			'sails-linker-gulp:prodStylesRelativeJade',
-			'sails-linker-gulp:devTplJade' */
+			'sails-linker-gulp:prodAssetsRelative',
+			'sails-linker-gulp:prodViewsRelative',
 			cb
 		);
 	});

--- a/templates/tasks/register/prod.js
+++ b/templates/tasks/register/prod.js
@@ -2,15 +2,12 @@ module.exports = function (gulp, plugins) {
 	gulp.task('prod', function(cb) {
 		plugins.sequence(
 			'compileAssets',
-			'concat',
-			'uglify',
-			'cssmin',
-			'sails-linker-gulp:prodJs',
-			'sails-linker-gulp:prodStyles',
-			'sails-linker-gulp:devTpl',
-			/*'sails-linker-gulp:prodJsJade',
-			'sails-linker-gulp:prodStylesJade',
-			'sails-linker-gulp:devTplJade' */
+			'concat:js',
+			'concat:css',
+			'uglify:dist',
+			'cssmin:dist',
+			'sails-linker-gulp:prodAssets',
+			'sails-linker-gulp:prodViews',
 			cb
 		);
 	});


### PR DESCRIPTION
This fixes the linking of script and link tags into html files in the assets folder and into html-/ejs files in the views folder. There where also problems with calling the tasks concat, uglify and cssmin, that has also been fixed. It does also fix a little typo in watch.js.
