### PR TITLE
Update coffee.js

### DIFF
--- a/templates/tasks/config/coffee.js
+++ b/templates/tasks/config/coffee.js
@@ -9,7 +9,7 @@
  */
 module.exports = function(gulp, plugins, growl) {
 	gulp.task('coffee:dev', function() {
-		gulp.src('assets/js/**/**.coffee')
+		return gulp.src('assets/js/**/**.coffee')
 		.pipe(plugins.coffee({bare: true}).on('error', plugins.util.log))
 		.pipe(gulp.dest('.tmp/public/js/'))
 		.pipe(plugins.if(growl, plugins.notify({ message: 'Coffee compile task complete' })));


### PR DESCRIPTION
without this return gulp will not know when the coffe files are compiled and start the linker to soon